### PR TITLE
Open a pull request

### DIFF
--- a/src/services/codefixes/fixUnusedIdentifier.ts
+++ b/src/services/codefixes/fixUnusedIdentifier.ts
@@ -154,6 +154,13 @@ namespace ts.codefix {
         }
         if (isIdentifier(token) && canPrefix(token)) {
             changes.replaceNode(sourceFile, token, createIdentifier(`_${token.text}`));
+            if (isParameter(token.parent)) {
+                getJSDocParameterTags(token.parent).forEach((tag) => {
+                    if (isIdentifier(tag.name)) {
+                        changes.replaceNode(sourceFile, tag.name, createIdentifier(`_${tag.name.text}`));
+                    }
+                });
+            }
         }
     }
 

--- a/tests/cases/fourslash/codeFixUnusedIdentifier_all_prefix.ts
+++ b/tests/cases/fourslash/codeFixUnusedIdentifier_all_prefix.ts
@@ -3,6 +3,10 @@
 // @noUnusedLocals: true
 // @noUnusedParameters: true
 
+/////**
+//// * @param a First parameter.
+//// * @param b Second parameter.
+//// */ 
 ////function f(a, b) {
 ////    const x = 0; // Can't be prefixed, ignored
 ////}
@@ -12,7 +16,11 @@ verify.codeFixAll({
     fixId: "unusedIdentifier_prefix",
     fixAllDescription: "Prefix all unused declarations with '_' where possible",
     newFileContent:
-`function f(_a, _b) {
+`/**
+ * @param _a First parameter.
+ * @param _b Second parameter.
+ */ 
+function f(_a, _b) {
     const x = 0; // Can't be prefixed, ignored
 }
 type Length<T> = T extends ArrayLike<infer _U> ? number : never;`,

--- a/tests/cases/fourslash/codeFixUnusedIdentifier_prefix.ts
+++ b/tests/cases/fourslash/codeFixUnusedIdentifier_prefix.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts' />
+
+// @noUnusedLocals: true
+// @noUnusedParameters: true
+
+/////**
+//// * @param a
+//// * @param b
+//// */
+////function f(a, b) {
+////    const x = a;
+////}
+
+verify.codeFix({
+    description: "Prefix 'b' with an underscore",
+    index: 1,
+    newFileContent:
+`/**
+ * @param a
+ * @param _b
+ */
+function f(a, _b) {
+    const x = a;
+}`,
+});


### PR DESCRIPTION
…152)

* Fix prepending unused TypeScript variables with underscore doesn't rename JSDoc @param.
Fix test for quick fix "Prefix all unused declarations with '_' where possible".
Fixes #33021.

* Replace FindAllReferences.Core.eachSymbolReferenceInFile function call to more ligher call of getJSDocParameterTags when searching for a parameter in jsdoc.

* Remove redundant constant declaration.

* Add test for prefix single unused parameter in jsdoc.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
